### PR TITLE
Add globalTaskFilterReplace to enhance task text filtering

### DIFF
--- a/tasksCalendar/view.js
+++ b/tasksCalendar/view.js
@@ -1,4 +1,4 @@
-let {pages, view, firstDayOfWeek, globalTaskFilter, dailyNoteFolder, dailyNoteFormat, startPosition, upcomingDays, css, options} = input;
+let {pages, view, firstDayOfWeek, globalTaskFilter, globalTaskFilterReplace, dailyNoteFolder, dailyNoteFormat, startPosition, upcomingDays, css, options} = input;
 
 // Error Handling
 if (!pages && pages!="") { dv.span('> [!ERROR] Missing pages parameter\n> \n> Please set the pages parameter like\n> \n> `pages: ""`'); return false };
@@ -120,9 +120,9 @@ function getMeta(tasks) {
 			tasks[i].priority = "C";
 		}
 		if (globalTaskFilter) {
-			tasks[i].text = tasks[i].text.replaceAll(globalTaskFilter,"");
+			tasks[i].text = tasks[i].text.replaceAll(globalTaskFilter, globalTaskFilterReplace ?? "");
 		} else {
-			tasks[i].text = tasks[i].text.replaceAll("#task","");
+			tasks[i].text = tasks[i].text.replaceAll("#task", globalTaskFilterReplace ?? "");
 		};
 		tasks[i].text = tasks[i].text.replaceAll("[[","");
 		tasks[i].text = tasks[i].text.replaceAll("]]","");


### PR DESCRIPTION
## Whats changing
When using `globalTaskFilter`, sometimes there still can be important info in what is being filtered out. This PR adds a new input called `globalTaskFilterReplace` that will replace the text that matches `globalTextFilter`.

## Why?
For my calendar I use: `globalTaskFilter: /#(?:.+\/)?(.+?)\/(.+?)(?=\s)/g, globalTaskFilterReplace: "$2 $1"` which means that any task like "#Assessment/Exam/LinAlg 3" will be converted into `LinAlg Exam 3`. There are a bunch of other cases where part of a task might be overly verbose but still provides important information.